### PR TITLE
Add Ansible code to license Burp Suite Pro

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,11 +4,21 @@ third_party_bucket_name: cisa-cool-third-party-production
 # The name of the S3 object corresponding to the Burp Suite Pro Linux
 # installer
 burp_suite_installer_object_name: burpsuite_pro_linux_v2020_11.sh
+# The name of the S3 object corresponding to the Burp Suite Pro
+# license
+burp_suite_license_object_name: burpsuite_pro.license
 # Prerequisites needed to install Burp Suite Pro
 burp_suite_installation_prerequisites:
+  # We use expect directly to perform the licensing.  We can't use the
+  # ansible.builtin.expect module because the process outputs the
+  # entire license text, which overflows the default input buffer size
+  # of 2000 bytes.  Hence we need to increase the input buffer size
+  # for expect, and this cannot be done via the ansible.builtin.expect
+  # module.
+  - expect
   # The installer application requires this
   - libfreetype6
-  # This is required for the Ansible expect module
+  # This is required for the ansible.builtin.expect module
   - python3-pexpect
 # The directory where Burp Suite Pro should be installed
 burp_suite_install_directory: /usr/local/BurpSuitePro

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,14 +7,17 @@
 
 - name: Install Burp Suite Pro
   block:
-    - name: Grab Burp Suite Pro installer from S3
+    - name: Grab Burp Suite Pro installer and license from S3
       ansible.builtin.aws_s3:
         bucket: "{{ third_party_bucket_name }}"
-        object: "{{ burp_suite_installer_object_name }}"
-        dest: /tmp/{{ burp_suite_installer_object_name }}
+        object: "{{ item }}"
+        dest: /tmp/{{ item }}
         mode: get
       become: no
       delegate_to: localhost
+      loop:
+        - "{{ burp_suite_installer_object_name }}"
+        - "{{ burp_suite_license_object_name }}"
 
     - name: Copy the Burp Suite Pro installer
       ansible.builtin.copy:
@@ -57,20 +60,55 @@
           "Create symlinks\\?": "y"
           "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ burp_suite_symlinks_directory }}"
         timeout: 300
-      # This failed_when clause is required because the installer
-      # command returns a nonzero return code even when it succeeds.
-      failed_when:
-        - install_command.rc != 0
-        - install_command.rc != 1
-        - install_command.rc != 2
-      register: install_command
 
-    - name: Delete local copy of Burp Suite Pro installer
+    # We can't use the ansible.builtin.expect module here because the
+    # licensing process outputs the entire license text, which
+    # overflows the default input buffer size of 2000 bytes.  Hence we
+    # need to increase the input buffer size for expect, and this
+    # cannot be done via the ansible.builtin.expect module.
+    - name: License Burp Suite Pro
+      ansible.builtin.shell: |
+        # $ ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
+        # Burp Suite Professional Terms & Conditions of Supply
+        #
+        # <snip>
+        # License text
+        # </snip>
+        # Do you accept the license agreement? (y/n)
+        # y
+        # This version of Burp requires a license key. To continue, please paste your license key below.
+        # <license key>
+        # Burp will now attempt to contact the license server and activate your license. This will require Internet access.
+        # NOTE: license activations are monitored. If you perform too many activations, further activations for this license may be prevented.
+        # Enter preferred activation method (o=online activation; m=manual activation; r=re-enter license key)
+        # o
+        # Your license is successfully installed and activated.
+
+        # Increase the input buffer size from 2000 to 10000 bytes
+        match-max 10000
+        spawn ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
+
+        expect "Do you accept the license agreement\\?"
+        send "y\n"
+
+        expect "To continue, please paste your license key below\\."
+        send "{{ lookup('file', '/tmp/' + burp_suite_license_object_name) }}"
+
+        expect "Enter preferred activation method"
+        send "o\n"
+      args:
+        chdir: "{{ burp_suite_install_directory }}"
+        executable: /usr/bin/expect
+
+    - name: Delete local copies of Burp Suite Pro installer and license file
       ansible.builtin.file:
-        path: /tmp/{{ burp_suite_installer_object_name }}
+        path: /tmp/{{ item }}
         state: absent
       become: no
       delegate_to: localhost
+      loop:
+        - "{{ burp_suite_installer_object_name }}"
+        - "{{ burp_suite_license_object_name }}"
 
     - name: Delete remote copy of Burp Suite Pro installer
       ansible.builtin.file:


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some Ansible code to license Burp Suite Pro after it is installed.

I attempted this before, but the licensing process would often fail.  I believe this is because we actually have to use `expect` directly to perform the licensing, as I have done here.  We can't use the `ansible.builtin.expect` module because the licensing process outputs the entire license text, which overflows the default input buffer size of 2000 bytes.  Hence we need to increase the input buffer size for `expect`, and this cannot be done via the `ansible.builtin.expect` module.

## 💭 Motivation and Context ##

Pre-licensing was requested by the assessors in #1.

Resolves #1.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
