### PR TITLE
Allow per-user licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ None.
   third-party software is located.  Defaults to
   "cisa-cool-third-party-production".
 * `users` - a list of users for whom Burp Suite Pro should be
-  licensed.  (Burp Suite pro must be licensed separately for each user
+  licensed.  (Burp Suite Pro must be licensed separately for each user
   that requires it.)  Defaults to only the `root` user.
 
 ## Dependencies ##

--- a/README.md
+++ b/README.md
@@ -59,20 +59,22 @@ None.
 
 ## Role Variables ##
 
-* `burp_suite_install_directory` - the directory where Burp Suite Pro
-  should be installed.  Defaults to "/usr/local/BurpSuitePro".
-* `burp_suite_installer_object_name` - the name of the S3 object
-  corresponding to the Burp Suite Pro Linux installer.  Defaults to
+* `install_directory` - the directory where Burp Suite Pro should be
+  installed.  Defaults to "/usr/local/BurpSuitePro".
+* `installer_object_name` - the name of the S3 object corresponding to
+  the Burp Suite Pro Linux installer.  Defaults to
   "burpsuite_pro_linux_v2020_11.sh".
-* `burp_suite_license_object_name` - the name of the S3 object
-  corresponding to the Burp Suite Pro license.  Defaults to
-  "burpsuite_pro.license".
-* `burp_suite_symlinks_directory` - the directory where symlinks to
-  the Burp Suite Pro executables should be created.  Defaults to
+* `license_object_name` - the name of the S3 object corresponding to
+  the Burp Suite Pro license.  Defaults to "burpsuite_pro.license".
+* `symlinks_directory` - the directory where symlinks to the Burp
+  Suite Pro executables should be created.  Defaults to
   "/usr/local/bin".
 * `third_party_bucket_name` - the name of the AWS S3 bucket where
   third-party software is located.  Defaults to
   "cisa-cool-third-party-production".
+* `users` - a list of users for whom Buro Suite Pro should be
+  licensed.  (Burp Suite pro must be licensed separately for each user
+  that requires it.)  Defaults to only the `root` user.
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ None.
 * `third_party_bucket_name` - the name of the AWS S3 bucket where
   third-party software is located.  Defaults to
   "cisa-cool-third-party-production".
-* `users` - a list of users for whom Buro Suite Pro should be
+* `users` - a list of users for whom Burp Suite Pro should be
   licensed.  (Burp Suite pro must be licensed separately for each user
   that requires it.)  Defaults to only the `root` user.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,17 @@
 ---
 # The name of the AWS S3 bucket where third-party software is located
 third_party_bucket_name: cisa-cool-third-party-production
+
 # The name of the S3 object corresponding to the Burp Suite Pro Linux
 # installer
-burp_suite_installer_object_name: burpsuite_pro_linux_v2020_11.sh
+installer_object_name: burpsuite_pro_linux_v2020_11.sh
+
 # The name of the S3 object corresponding to the Burp Suite Pro
 # license
-burp_suite_license_object_name: burpsuite_pro.license
+license_object_name: burpsuite_pro.license
+
 # Prerequisites needed to install Burp Suite Pro
-burp_suite_installation_prerequisites:
+installation_prerequisites:
   # We use expect directly to perform the licensing.  We can't use the
   # ansible.builtin.expect module because the process outputs the
   # entire license text, which overflows the default input buffer size
@@ -20,8 +23,10 @@ burp_suite_installation_prerequisites:
   - libfreetype6
   # This is required for the ansible.builtin.expect module
   - python3-pexpect
+
 # The directory where Burp Suite Pro should be installed
-burp_suite_install_directory: /usr/local/BurpSuitePro
+install_directory: /usr/local/BurpSuitePro
+
 # The directory where symlinks to the Burp Suite Pro executables
 # should be created
-burp_suite_symlinks_directory: /usr/local/bin
+symlinks_directory: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,7 @@ install_directory: /usr/local/BurpSuitePro
 # The directory where symlinks to the Burp Suite Pro executables
 # should be created
 symlinks_directory: /usr/local/bin
+
+# Burp Suite Pro must be licensed individually for each user
+users:
+  - root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,8 @@
       args:
         chdir: "{{ install_directory }}"
         executable: /usr/bin/expect
+      become_user: "{{ item }}"
+      loop: "{{ users }}"
 
     - name: Delete local copies of Burp Suite Pro installer and license file
       ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # Check if Burp Suite Pro is already installed
 - name: Check if Burp Suite Pro is already installed
   ansible.builtin.stat:
-    path: "{{ burp_suite_install_directory }}"
+    path: "{{ install_directory }}"
   register: burp_suite_directory
 
 - name: Install Burp Suite Pro
@@ -16,23 +16,23 @@
       become: no
       delegate_to: localhost
       loop:
-        - "{{ burp_suite_installer_object_name }}"
-        - "{{ burp_suite_license_object_name }}"
+        - "{{ installer_object_name }}"
+        - "{{ license_object_name }}"
 
     - name: Copy the Burp Suite Pro installer
       ansible.builtin.copy:
-        dest: /tmp/{{ burp_suite_installer_object_name }}
+        dest: /tmp/{{ installer_object_name }}
         mode: 0700
-        src: /tmp/{{ burp_suite_installer_object_name }}
+        src: /tmp/{{ installer_object_name }}
 
     - name: Install Burp Suite Pro installation prerequisites
       ansible.builtin.package:
-        name: "{{ burp_suite_installation_prerequisites }}"
+        name: "{{ installation_prerequisites }}"
 
     - name: Install Burp Suite Pro
       ansible.builtin.expect:
-        command: /tmp/{{ burp_suite_installer_object_name }}
-        creates: "{{ burp_suite_install_directory }}"
+        command: /tmp/{{ installer_object_name }}
+        creates: "{{ install_directory }}"
         responses:
           # $ sudo ./burpsuite_pro_linux_v2020_11.sh
           # Unpacking JRE ...
@@ -56,9 +56,9 @@
           # Setup has finished installing Burp Suite Professional on your computer.
           # Finishing installation ...
           "This will install Burp Suite Professional on your computer\\.": o
-          "Where should Burp Suite Professional be installed\\?": "{{ burp_suite_install_directory }}"
+          "Where should Burp Suite Professional be installed\\?": "{{ install_directory }}"
           "Create symlinks\\?": "y"
-          "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ burp_suite_symlinks_directory }}"
+          "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ symlinks_directory }}"
         timeout: 300
 
     # We can't use the ansible.builtin.expect module here because the
@@ -92,12 +92,12 @@
         send "y\n"
 
         expect "To continue, please paste your license key below\\."
-        send "{{ lookup('file', '/tmp/' + burp_suite_license_object_name) }}"
+        send "{{ lookup('file', '/tmp/' + license_object_name) }}"
 
         expect "Enter preferred activation method"
         send "o\n"
       args:
-        chdir: "{{ burp_suite_install_directory }}"
+        chdir: "{{ install_directory }}"
         executable: /usr/bin/expect
 
     - name: Delete local copies of Burp Suite Pro installer and license file
@@ -107,12 +107,13 @@
       become: no
       delegate_to: localhost
       loop:
-        - "{{ burp_suite_installer_object_name }}"
-        - "{{ burp_suite_license_object_name }}"
+        - "{{ installer_object_name }}"
+        - "{{ license_object_name }}"
 
+    # The licensing process appears to delete the license file for you
     - name: Delete remote copy of Burp Suite Pro installer
       ansible.builtin.file:
-        path: /tmp/{{ burp_suite_installer_object_name }}
+        path: /tmp/{{ installer_object_name }}
         state: absent
 
   when: not burp_suite_directory.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,8 @@
 
         expect "Enter preferred activation method"
         send "o\n"
+
+        expect "Your license is successfully installed and activated\\."
       args:
         chdir: "{{ install_directory }}"
         executable: /usr/bin/expect

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,8 @@
         # o
         # Your license is successfully installed and activated.
 
+        # Disable any internal timeout that expect has
+        set timeout -1
         # Increase the input buffer size from 2000 to 10000 bytes
         match_max 10000
         spawn ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,11 +19,15 @@
         - "{{ installer_object_name }}"
         - "{{ license_object_name }}"
 
-    - name: Copy the Burp Suite Pro installer
+    - name: Copy the Burp Suite Pro installer and license
       ansible.builtin.copy:
-        dest: /tmp/{{ installer_object_name }}
-        mode: 0700
-        src: /tmp/{{ installer_object_name }}
+        dest: /tmp/{{ item.file }}
+        mode: "{{ item.mode }}"
+        src: /tmp/{{ item.file }}
+      loop:
+        - {file: "{{ installer_object_name }}", mode: "0700"}
+        # Other users must be able to read the license file as well
+        - {file: "{{ license_object_name }}", mode: "0644"}
 
     - name: Install Burp Suite Pro installation prerequisites
       ansible.builtin.package:
@@ -112,10 +116,12 @@
         - "{{ installer_object_name }}"
         - "{{ license_object_name }}"
 
-    # The licensing process appears to delete the license file for you
-    - name: Delete remote copy of Burp Suite Pro installer
+    - name: Delete remote copy of Burp Suite Pro installer and license file
       ansible.builtin.file:
-        path: /tmp/{{ installer_object_name }}
+        path: /tmp/{{ item }}
         state: absent
+      loop:
+        - "{{ installer_object_name }}"
+        - "{{ license_object_name }}"
 
   when: not burp_suite_directory.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,14 +89,14 @@
         # Your license is successfully installed and activated.
 
         # Increase the input buffer size from 2000 to 10000 bytes
-        match-max 10000
+        match_max 10000
         spawn ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
 
         expect "Do you accept the license agreement\\?"
         send "y\n"
 
         expect "To continue, please paste your license key below\\."
-        send "{{ lookup('file', '/tmp/' + license_object_name) }}"
+        send "{{ lookup('file', '/tmp/' + license_object_name) }}\n"
 
         expect "Enter preferred activation method"
         send "o\n"


### PR DESCRIPTION
## 🗣 Description ##

This pull request allows one to specify a list of users for whom Burp Suite Pro should be licensed.  If no such list is specified then Burp Suite Pro is licensed only for the `root` user.

I also took the opportunity to remove the redundant leading `burp_suite_` from several of the variables in `defaults/main.yml`.

## 💭 Motivation and Context ##

Licensing Burp Suite pro as _root_, for example, only allows _root_ to use the software.  Each user that requires Burp Suite Pro must be licensed separately.

I noticed this when building a new Kali AMI that included the changes from #4.  The `vnc` user was still not able to run burp Suite Pro without specifying a license, even though the software had been licensed under the `root` user.  After some investigation, I realized that Burp Suite Pro must be licensed separate for each user that needs to use it.

## 🧪 Testing ##

All `pre-commit` hooks and a  `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
