### PR TITLE
Rename installer object

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ None.
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | install\_directory | The directory where Burp Suite Pro should be installed. | `/usr/local/BurpSuitePro` | No |
-| installer\_object\_name | The name of the S3 object corresponding to the Burp Suite Pro Linux installer. | `burpsuite\_pro\_linux\_v2020\_11.sh` | No |
+| installer\_object\_name | The name of the S3 object corresponding to the Burp Suite Pro Linux installer. | `burpsuite\_pro\_linux.sh` | No |
 | license\_object\_name | The name of the S3 object corresponding to the Burp Suite Pro license. | `burpsuite\_pro.license` | No |
 | symlinks_directory | The directory where symlinks to the Burp Suite Pro executables should be created. | `/usr/local/bin` | No |
 | third\_party\_bucket\_name | The name of the AWS S3 bucket where third-party software is located. | `cisa-cool-third-party-production` | No |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ third_party_bucket_name: cisa-cool-third-party-production
 
 # The name of the S3 object corresponding to the Burp Suite Pro Linux
 # installer
-installer_object_name: burpsuite_pro_linux_v2020_11.sh
+installer_object_name: burpsuite_pro_linux.sh
 
 # The name of the S3 object corresponding to the Burp Suite Pro
 # license

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,11 @@
           # Where should Burp Suite Professional be installed?
           # [/usr/local/BurpSuitePro]
           #
+          # Select the file associations you want to create; clear the file associations
+          # you do not want to create. Click Next when you are ready to continue.
+          # Burp Suite Project File (*.burp)
+          # Yes [y, Enter], No [n]
+          #
           # Create symlinks?
           # Yes [y, Enter], No [n]
           #
@@ -61,8 +66,9 @@
           # Finishing installation ...
           "This will install Burp Suite Professional on your computer\\.": o
           "Where should Burp Suite Professional be installed\\?": "{{ install_directory }}"
-          "Create symlinks\\?": "y"
-          "Select the folder where you would like Burp Suite Professional to create symlinks, then click Next": "{{ symlinks_directory }}"
+          "Burp Suite Project File": "y"
+          "Create symlinks": "y"
+          "Select the folder where you would like Burp Suite Professional to create symlinks": "{{ symlinks_directory }}"
         timeout: 300
 
     # We can't use the ansible.builtin.expect module here because the

--- a/terraform/user.tf
+++ b/terraform/user.tf
@@ -17,8 +17,7 @@ module "user" {
   ssm_parameters = ["/dummy/value"]
 }
 
-# Attach third-party S3 bucket read-only policy to the production
-# EC2AMICreate role
+# Attach third-party S3 bucket read-only policy to the production role
 resource "aws_iam_role_policy_attachment" "thirdpartybucketread_production" {
   provider = aws.images_production_provisionaccount
 
@@ -26,8 +25,7 @@ resource "aws_iam_role_policy_attachment" "thirdpartybucketread_production" {
   role       = module.user.production_role.name
 }
 
-# Attach third-party S3 bucket read-only policy to the staging
-# EC2AMICreate role
+# Attach third-party S3 bucket read-only policy to the staging role
 resource "aws_iam_role_policy_attachment" "thirdpartybucketread_staging" {
   provider = aws.images_staging_provisionaccount
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,7 +21,7 @@ variable "production_objects" {
   description = "The Burp Suite Pro installer and license objects inside the production bucket."
   default = [
     "burpsuite_pro.license",
-    "burpsuite_pro_linux_v2020_11.sh",
+    "burpsuite_pro_linux.sh",
   ]
 }
 
@@ -36,7 +36,7 @@ variable "staging_objects" {
   description = "The Burp Suite Pro installer and license objects inside the staging bucket."
   default = [
     "burpsuite_pro.license",
-    "burpsuite_pro_linux_v2020_11.sh",
+    "burpsuite_pro_linux.sh",
   ]
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the name of the installer object in the third-party S3 bucket.

## 💭 Motivation and context ##

The name of the installer object in the S3 bucket has been changed, so we need to adjust it here as well.  The new name is less specific, which should allow us to upload a new version of the installer in the future without having to modify this Ansible role.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
