### PR TITLE
Add CLI flag necessary for Java 16

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,22 +94,43 @@
         # o
         # Your license is successfully installed and activated.
 
-        # Disable any internal timeout that expect has
-        set timeout -1
+        # Increase timeout from 10 to 300 seconds
+        set timeout 300
         # Increase the input buffer size from 2000 to 10000 bytes
         match_max 10000
         spawn ./jre/bin/java -Djava.awt.headless=true --illegal-access=permit -jar ./burpsuite_pro.jar
 
-        expect "Do you accept the license agreement\\?"
-        send "y\n"
+        expect {
+          "Do you accept the license agreement\\?" {
+            send "y\n"
+          } default {
+            exit 1
+          }
+        }
 
-        expect "To continue, please paste your license key below\\."
-        send "{{ lookup('file', '/tmp/' + license_object_name) }}\n"
+        expect {
+          "To continue, please paste your license key below\\." {
+            send "{{ lookup('file', '/tmp/' + license_object_name) }}\n"
+          } default {
+            exit 1
+          }
+        }
 
-        expect "Enter preferred activation method"
-        send "o\n"
+        expect {
+          "Enter preferred activation method" {
+            send "o\n"
+          } default {
+            exit 1
+          }
+        }
 
-        expect "Your license is successfully installed and activated\\."
+        expect {
+          "Your license is successfully installed and activated\\." {
+            exit 0
+          } default {
+            exit 1
+          }
+        }
       args:
         chdir: "{{ install_directory }}"
         executable: /usr/bin/expect

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,7 @@
     # cannot be done via the ansible.builtin.expect module.
     - name: License Burp Suite Pro
       ansible.builtin.shell: |
-        # $ ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
+        # $ ./jre/bin/java -Djava.awt.headless=true --illegal-access=permit -jar ./burpsuite_pro.jar
         # Burp Suite Professional Terms & Conditions of Supply
         #
         # <snip>
@@ -98,7 +98,7 @@
         set timeout -1
         # Increase the input buffer size from 2000 to 10000 bytes
         match_max 10000
-        spawn ./jre/bin/java -Djava.awt.headless=true -jar ./burpsuite_pro.jar
+        spawn ./jre/bin/java -Djava.awt.headless=true --illegal-access=permit -jar ./burpsuite_pro.jar
 
         expect "Do you accept the license agreement\\?"
         send "y\n"


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds a CLI flag necessary when running Burp Suite Pro via Java 16.  Java 16 is the JRE that is now installed alongside Burp Suite Pro.
- Modifies the `expect` script to return a failure code if an expected prompt is not seen.

## 💭 Motivation and context ##

- Burp Suite Pro cannot be licensed via the CLI without this extra flag.
- The previous code would exit successfully even if prompts were not seen at all.  The changes in this PR should stop the licensing process from silently failing in the future.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also verified that the new `expect` code indeed causes Ansible to error out if not all the expected prompts are seen.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
