### PR TITLE
Prefer long command line options for clarity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,4 +18,4 @@ def test_bsp_installed(host):
     assert directory.exists
     assert directory.is_directory
     # Make sure that the directory is not empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {dir_full_path})" ]')


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies a test to prefer a long command line option.

## 💭 Motivation and context ##

We prefer long command line options as their function is usually more obvious and thus we avoid having to read a `man` page to understand what they are doing.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.