### PR TITLE
Add no_log to the task that licenses BSP

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,6 +142,7 @@
         executable: /usr/bin/expect
       become_user: "{{ item }}"
       loop: "{{ users }}"
+      no_log: yes
 
     - name: Delete local copies of Burp Suite Pro installer and license file
       ansible.builtin.file:


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the `no_log` attribute to the task that licenses Burp Suite Pro.

## 💭 Motivation and context ##

When this task fails, the actual license can appear in the output.  We do not want this to happen in public builds.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.