### PR TITLE
Remove code that licenses Burp Suite Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,8 @@ None.
 |----------|-------------|---------|----------|
 | burp\_suite\_pro\_install\_directory | The directory where Burp Suite Pro should be installed. | `/usr/local/BurpSuitePro` | No |
 | burp\_suite\_pro\_installer\_object\_name | The name of the S3 object corresponding to the Burp Suite Pro Linux installer. | `burpsuite\_pro\_linux.sh` | No |
-| burp\_suite\_pro\_license\_object\_name | The name of the S3 object corresponding to the Burp Suite Pro license. | `burpsuite\_pro.license` | No |
 | burp\_suite\_pro\_symlinks_directory | The directory where symlinks to the Burp Suite Pro executables should be created. | `/usr/local/bin` | No |
 | burp\_suite\_pro\_third\_party\_bucket\_name | The name of the AWS S3 bucket where third-party software is located. | `cisa-cool-third-party-production` | No |
-| burp\_suite\_pro\_users | A list of users for whom Burp Suite Pro should be licensed.  (Burp Suite Pro must be licensed separately for each user that requires it.) | `[root]` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,19 +6,8 @@ burp_suite_pro_third_party_bucket_name: cisa-cool-third-party-production
 # installer
 burp_suite_pro_installer_object_name: burpsuite_pro_linux.sh
 
-# The name of the S3 object corresponding to the Burp Suite Pro
-# license
-burp_suite_pro_license_object_name: burpsuite_pro.license
-
 # Prerequisites needed to install Burp Suite Pro
 burp_suite_pro_installation_prerequisites:
-  # We use expect directly to perform the licensing.  We can't use the
-  # ansible.builtin.expect module because the process outputs the
-  # entire license text, which overflows the default input buffer size
-  # of 2000 bytes.  Hence we need to increase the input buffer size
-  # for expect, and this cannot be done via the ansible.builtin.expect
-  # module.
-  - expect
   # The installer application requires this
   - libfreetype6
   # This is required for the ansible.builtin.expect module
@@ -30,7 +19,3 @@ burp_suite_pro_install_directory: /usr/local/BurpSuitePro
 # The directory where symlinks to the Burp Suite Pro executables
 # should be created
 burp_suite_pro_symlinks_directory: /usr/local/bin
-
-# Burp Suite Pro must be licensed individually for each user
-burp_suite_pro_users:
-  - root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install Burp Suite Pro
   when: not burp_suite_directory.stat.exists
   block:
-    - name: Grab Burp Suite Pro installer and license from S3
+    - name: Grab Burp Suite Pro installer from S3
       ansible.builtin.aws_s3:
         bucket: "{{ burp_suite_pro_third_party_bucket_name }}"
         object: "{{ burp_suite_pro_installer_object_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,24 +11,17 @@
     - name: Grab Burp Suite Pro installer and license from S3
       ansible.builtin.aws_s3:
         bucket: "{{ burp_suite_pro_third_party_bucket_name }}"
-        object: "{{ item }}"
-        dest: /tmp/{{ item }}
+        object: "{{ burp_suite_pro_installer_object_name }}"
+        dest: /tmp/{{ burp_suite_pro_installer_object_name }}
         mode: get
       become: no
       delegate_to: localhost
-      loop:
-        - "{{ burp_suite_pro_installer_object_name }}"
-        - "{{ burp_suite_pro_license_object_name }}"
 
-    - name: Copy the Burp Suite Pro installer and license
+    - name: Copy the Burp Suite Pro installer
       ansible.builtin.copy:
-        dest: /tmp/{{ item.file }}
-        mode: "{{ item.mode }}"
-        src: /tmp/{{ item.file }}
-      loop:
-        - {file: "{{ burp_suite_pro_installer_object_name }}", mode: "0700"}
-        # Other users must be able to read the license file as well
-        - {file: "{{ burp_suite_pro_license_object_name }}", mode: "0644"}
+        dest: /tmp/{{ burp_suite_pro_installer_object_name }}
+        mode: "0700"
+        src: /tmp/{{ burp_suite_pro_installer_object_name }}
 
     - name: Install Burp Suite Pro installation prerequisites
       ansible.builtin.package:
@@ -72,93 +65,14 @@
           "Select the folder where you would like Burp Suite Professional to create symlinks": "{{ burp_suite_pro_symlinks_directory }}"
         timeout: 300
 
-    # We can't use the ansible.builtin.expect module here because the
-    # licensing process outputs the entire license text, which
-    # overflows the default input buffer size of 2000 bytes.  Hence we
-    # need to increase the input buffer size for expect, and this
-    # cannot be done via the ansible.builtin.expect module.
-    #
-    # The noqa is necessary because, as far as I can tell, the
-    # licensing process does not create any new files or directories;
-    # therefore, I am unable to add a when clause for this task to
-    # only run it when necessary and ansible-lint (rightly) complains
-    # about this.
-    - name: License Burp Suite Pro  # noqa no-changed-when
-      ansible.builtin.shell: |
-        # $ ./jre/bin/java -Djava.awt.headless=true --illegal-access=permit -jar ./burpsuite_pro.jar
-        # Burp Suite Professional Terms & Conditions of Supply
-        #
-        # <snip>
-        # License text
-        # </snip>
-        # Do you accept the license agreement? (y/n)
-        # y
-        # This version of Burp requires a license key. To continue, please paste your license key below.
-        # <license key>
-        # Burp will now attempt to contact the license server and activate your license. This will require Internet access.
-        # NOTE: license activations are monitored. If you perform too many activations, further activations for this license may be prevented.
-        # Enter preferred activation method (o=online activation; m=manual activation; r=re-enter license key)
-        # o
-        # Your license is successfully installed and activated.
-
-        # Increase timeout from 10 to 300 seconds
-        set timeout 300
-        # Increase the input buffer size from 2000 to 10000 bytes
-        match_max 10000
-        spawn ./jre/bin/java -Djava.awt.headless=true --illegal-access=permit -jar ./burpsuite_pro.jar
-
-        expect {
-          "Do you accept the license agreement\\?" {
-            send "y\n"
-          } default {
-            exit 1
-          }
-        }
-
-        expect {
-          "To continue, please paste your license key below\\." {
-            send "{{ lookup('file', '/tmp/' + burp_suite_pro_license_object_name) }}\n"
-          } default {
-            exit 1
-          }
-        }
-
-        expect {
-          "Enter preferred activation method" {
-            send "o\n"
-          } default {
-            exit 1
-          }
-        }
-
-        expect {
-          "Your license is successfully installed and activated\\." {
-            exit 0
-          } default {
-            exit 1
-          }
-        }
-      args:
-        chdir: "{{ burp_suite_pro_install_directory }}"
-        executable: /usr/bin/expect
-      become_user: "{{ item }}"
-      loop: "{{ burp_suite_pro_users }}"
-      no_log: yes
-
-    - name: Delete local copies of Burp Suite Pro installer and license file
+    - name: Delete local copies of Burp Suite Pro installer
       ansible.builtin.file:
-        path: /tmp/{{ item }}
+        path: /tmp/{{ burp_suite_pro_installer_object_name }}
         state: absent
       become: no
       delegate_to: localhost
-      loop:
-        - "{{ burp_suite_pro_installer_object_name }}"
-        - "{{ burp_suite_pro_license_object_name }}"
 
-    - name: Delete remote copy of Burp Suite Pro installer and license file
+    - name: Delete remote copy of Burp Suite Pro installer
       ansible.builtin.file:
-        path: /tmp/{{ item }}
+        path: /tmp/{{ burp_suite_pro_installer_object_name }}
         state: absent
-      loop:
-        - "{{ burp_suite_pro_installer_object_name }}"
-        - "{{ burp_suite_pro_license_object_name }}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,7 @@ variable "aws_region" {
 
 variable "production_bucket_name" {
   type        = string
-  description = "The name of the S3 bucket where the production Burp Suite Pro intaller lives."
+  description = "The name of the S3 bucket where the production Burp Suite Pro installer lives."
   default     = "cisa-cool-third-party-production"
 }
 
@@ -26,7 +26,7 @@ variable "production_objects" {
 
 variable "staging_bucket_name" {
   type        = string
-  description = "The name of the S3 bucket where the staging Burp Suite Pro intaller lives."
+  description = "The name of the S3 bucket where the staging Burp Suite Pro installer lives."
   default     = "cisa-cool-third-party-staging"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,30 +12,28 @@ variable "aws_region" {
 
 variable "production_bucket_name" {
   type        = string
-  description = "The name of the S3 bucket where the production Burp Suite Pro intaller and license live."
+  description = "The name of the S3 bucket where the production Burp Suite Pro intaller lives."
   default     = "cisa-cool-third-party-production"
 }
 
 variable "production_objects" {
   type        = list(string)
-  description = "The Burp Suite Pro installer and license objects inside the production bucket."
+  description = "The Burp Suite Pro installer object inside the production bucket."
   default = [
-    "burpsuite_pro.license",
     "burpsuite_pro_linux.sh",
   ]
 }
 
 variable "staging_bucket_name" {
   type        = string
-  description = "The name of the S3 bucket where the staging Burp Suite Pro intaller and license live."
+  description = "The name of the S3 bucket where the staging Burp Suite Pro intaller lives."
   default     = "cisa-cool-third-party-staging"
 }
 
 variable "staging_objects" {
   type        = list(string)
-  description = "The Burp Suite Pro installer and license objects inside the staging bucket."
+  description = "The Burp Suite Pro installer object inside the staging bucket."
   default = [
-    "burpsuite_pro.license",
     "burpsuite_pro_linux.sh",
   ]
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the code that licenses Burp Suite Pro.

## 💭 Motivation and context ##

This all started because the license I was using expired.  This was found to cause a [build error](https://github.com/cisagov/kali-packer/actions/runs/8266179719/job/22613823230) in the testing that was done as part of cisagov/kali-packer#165.  I asked for an updated license. According to a Tech Ops lab manager, the terms of the BSP license have changed.  We can no longer build pre-licensed AMIs since licenses are assigned per-user; therefore, the licensing code must be removed.

This creates a hardship for our users, but I checked with @m1j09830 and he said he is aware of this change and is expecting it.

## 🧪 Testing ##

All automated tests pass.  In the testing that was done as part of cisagov/kali-packer#165, I verified that these changes fix the build error mentioned above.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.